### PR TITLE
LINEのトークンを環境ごとに出し分ける

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,4 @@
 APP_ENV=local
 CONTENTFUL_SPACE_ID=xxxxxxxx
 CONTENTFUL_ACCESS_TOKEN=xxxxxxxx
-LINE_TOKEN_TEST=xxxxxxxx
+LINE_NOTIFY_TOKEN=xxxxxxxx # dev / prd の出し分けは Netlify の機能を使っている

--- a/src/pages/api/receiveContactForm.ts
+++ b/src/pages/api/receiveContactForm.ts
@@ -44,8 +44,7 @@ const handler = async (
   const result: Result = await fetch("https://notify-api.line.me/api/notify", {
     method: "POST",
     headers: {
-      // todo: Prodと出し分ける
-      Authorization: `Bearer ${process.env.LINE_TOKEN_TEST}`,
+      Authorization: `Bearer ${process.env.LINE_NOTIFY_TOKEN}`,
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: new URLSearchParams({

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -5,6 +5,6 @@ declare namespace NodeJS {
     readonly APP_ENV: string;
     readonly CONTENTFUL_SPACE_ID: string;
     readonly CONTENTFUL_ACCESS_TOKEN: string;
-    readonly LINE_TOKEN_TEST: string;
+    readonly LINE_NOTIFY_TOKEN: string;
   }
 }


### PR DESCRIPTION
[Netlify の新機能](https://docs.netlify.com/environment-variables/overview/#value-per-deploy-context)により、複数用意しなくてよくなった。
ホスティング先を変える場合剥がしにくくなるデメリットはありそうだが、今は数も少ないのでいったん使ってみる。