### PR TITLE
フォームでライブ日程が送信できない問題を解決し、バリデーションを強化する

### DIFF
--- a/src/templates/Contact/Form/CategorySelect/CategoryOptionElements.tsx
+++ b/src/templates/Contact/Form/CategorySelect/CategoryOptionElements.tsx
@@ -1,11 +1,13 @@
 import { categories, type Category } from "@/types/ContactForm";
 
-export const CategoryOptionElements: React.FC = () => {
+interface Props {
+  defaultValue: string;
+}
+
+export const CategoryOptionElements: React.FC<Props> = (props) => {
   return (
     <>
-      <option value="default" disabled style={{ display: "none" }}>
-        - お問い合わせ種類 -
-      </option>
+      <option value={props.defaultValue}>- お問い合わせ種類 -</option>
       {(Object.keys(categories) as Category[]).map((element) => (
         <option value={element} key={element}>
           {categories[element]}

--- a/src/templates/Contact/Form/CategorySelect/ReserveCountOptionElements.tsx
+++ b/src/templates/Contact/Form/CategorySelect/ReserveCountOptionElements.tsx
@@ -1,11 +1,13 @@
 const MAX_TICKET_NUMBER = 5;
 
-export const ReserveCountOptionElements: React.FC = () => {
+interface Props {
+  defaultValue: string;
+}
+
+export const ReserveCountOptionElements: React.FC<Props> = (props) => {
   return (
     <>
-      <option value="" disabled>
-        - お取り置き枚数 -
-      </option>
+      <option value={props.defaultValue}>- お取り置き枚数 -</option>
       {[...Array(MAX_TICKET_NUMBER)].map((_, index) => {
         const value = index + 1;
         return (

--- a/src/templates/Contact/Form/CategorySelect/ReserveDateOptionElements.tsx
+++ b/src/templates/Contact/Form/CategorySelect/ReserveDateOptionElements.tsx
@@ -1,13 +1,15 @@
 import { LiveInformationContext } from "@/providers/LiveInformationProvider";
 import { useContext } from "react";
 
-export const ReserveDateOptionElements: React.FC = () => {
+interface Props {
+  defaultValue: string;
+}
+
+export const ReserveDateOptionElements: React.FC<Props> = (props) => {
   const { lives } = useContext(LiveInformationContext);
   return (
     <>
-      <option value="" disabled>
-        - お取り置き日程 -
-      </option>
+      <option value={props.defaultValue}>- お取り置き日程 -</option>
       {lives.map((element) => (
         <option key={element.date}>
           {/* todo: context 上でフォーマットする */}

--- a/src/templates/Contact/Form/CategorySelect/hooks.ts
+++ b/src/templates/Contact/Form/CategorySelect/hooks.ts
@@ -14,8 +14,20 @@ export const useHooks = () => {
     return userInput.category !== undefined;
   }, [userInput.category]);
 
+  // todo: Context 側に寄せる
+  const isSelectedSomeReserveDate = useMemo(() => {
+    return userInput.reservedate !== undefined;
+  }, [userInput.reservedate]);
+
+  // todo: Context 側に寄せる
+  const isSelectedSomeReserveCount = useMemo(() => {
+    return userInput.reservecount !== undefined;
+  }, [userInput.reservecount]);
+
   return {
     isSelectedLiveReserve,
     isSelectedSomeCategory,
+    isSelectedSomeReserveDate,
+    isSelectedSomeReserveCount,
   };
 };

--- a/src/templates/Contact/Form/CategorySelect/index.tsx
+++ b/src/templates/Contact/Form/CategorySelect/index.tsx
@@ -33,6 +33,7 @@ export const CategorySelect: React.FC<Props> = (props) => {
         <div className={styles["wrapper"]}>
           <Select
             className={styles["is-small"]}
+            onChange={props.onChange}
             disabled={lives.length === 0 || !hooks.isSelectedLiveReserve}
             name="reservedate"
           >

--- a/src/templates/Contact/Form/CategorySelect/index.tsx
+++ b/src/templates/Contact/Form/CategorySelect/index.tsx
@@ -14,38 +14,44 @@ interface Props {
 export const CategorySelect: React.FC<Props> = (props) => {
   const hooks = useHooks();
   const { lives } = useContext(LiveInformationContext);
+  const DEFAULT_VALUE = ""; // 初期状態で未選択にするために必要
 
   return (
     <>
       <Select
-        className={
-          hooks.isSelectedSomeCategory ? "" : styles["category-default"]
-        }
+        className={hooks.isSelectedSomeCategory ? "" : styles["select-default"]}
         name="category"
         onChange={props.onChange}
-        defaultValue="default" // todo: option 側と共通化する
+        defaultValue={DEFAULT_VALUE}
         required
       >
-        <CategoryOptionElements />
+        <CategoryOptionElements defaultValue={DEFAULT_VALUE} />
       </Select>
-      {/* todo: 別コンポーネントに切り出す */}
       {hooks.isSelectedLiveReserve && (
         <div className={styles["wrapper"]}>
           <Select
-            className={styles["is-small"]}
+            className={`${styles["is-small"]} ${
+              hooks.isSelectedSomeReserveDate ? "" : styles["select-default"]
+            }`}
             onChange={props.onChange}
             disabled={lives.length === 0 || !hooks.isSelectedLiveReserve}
+            defaultValue={DEFAULT_VALUE}
+            required
             name="reservedate"
           >
-            <ReserveDateOptionElements />
+            <ReserveDateOptionElements defaultValue={DEFAULT_VALUE} />
           </Select>
           <Select
-            className={styles["is-small"]}
+            className={`${styles["is-small"]} ${
+              hooks.isSelectedSomeReserveCount ? "" : styles["select-default"]
+            }`}
             disabled={lives.length === 0 || !hooks.isSelectedLiveReserve}
             onChange={props.onChange}
+            defaultValue={DEFAULT_VALUE}
+            required
             name="reservecount"
           >
-            <ReserveCountOptionElements />
+            <ReserveCountOptionElements defaultValue={DEFAULT_VALUE} />
           </Select>
         </div>
       )}

--- a/src/templates/Contact/Form/CategorySelect/style.module.scss
+++ b/src/templates/Contact/Form/CategorySelect/style.module.scss
@@ -10,6 +10,6 @@
 
 // 選択されていないときにグレーにするため
 // todo: Select コンポーネント側に書く方法を考える
-.category-default {
+.select-default {
   color: $placeholder;
 }


### PR DESCRIPTION
- onChange を渡していなかったので修正
- セレクトボックスが初期状態で選択されているように見えている事象を解決
- カテゴリ選択のセレクトボックスの `required` が動いていなかったので修正
  - (1)`select` に `required` を指定
  - (2) `option` に `value=""`
  - (3) `select` に `defaultValue=""` も必要
    - HTMLの仕様では (1), (2) だけでよいが、React は ```Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.``` が出るため (3) も必要