### PR TITLE
SVGの属性のエラーがコンソールに出ないようにする

### DIFF
--- a/src/components/LoadingIcon/index.tsx
+++ b/src/components/LoadingIcon/index.tsx
@@ -11,8 +11,8 @@ export const LoadingIcon: React.FC<Props> = (props) => (
     {...props}
   >
     <g fill="none" fillRule="evenodd">
-      <g stroke-width="2" transform="translate(1 1)">
-        <circle cx="18" cy="18" r="18" stroke-opacity=".5" />
+      <g strokeWidth="2" transform="translate(1 1)">
+        <circle cx="18" cy="18" r="18" strokeOpacity=".5" />
         <path d="M36 18c0-9.94-8.06-18-18-18">
           <animateTransform
             attributeName="transform"


### PR DESCRIPTION
fix:

```
Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
```

```
Warning: Invalid DOM property `stroke-opacity`. Did you mean `strokeOpacity`?
```