### PR TITLE
リロード直後もスクロール量を計算する

### DIFF
--- a/src/templates/SiteFloatingNavigation/hooks.ts
+++ b/src/templates/SiteFloatingNavigation/hooks.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export const useHooks = () => {
-  const [isScrollStart, setIsScrolStart] = useState(false);
-  const [isWindowTop, setIsWindowTop] = useState(false);
+  const [isScrollStarted, setIsScrollStarted] = useState(false);
+  const [isScrolled1vh, setIsScrolled1vh] = useState(false);
   const ref = useRef<HTMLElement>(null);
   const handleScroll = useCallback(() => {
     if (typeof window === undefined) return;
-    setIsScrolStart(window.pageYOffset > 0);
-    setIsWindowTop(
+    setIsScrollStarted(window.pageYOffset > 0);
+    setIsScrolled1vh(
       window.pageYOffset > window.innerHeight - ref.current!.clientHeight
     );
   }, []);
@@ -31,7 +31,7 @@ export const useHooks = () => {
 
   return {
     ref,
-    isScrollStart,
-    isWindowTop,
+    isScrollStarted,
+    isScrolled1vh,
   };
 };

--- a/src/templates/SiteFloatingNavigation/hooks.ts
+++ b/src/templates/SiteFloatingNavigation/hooks.ts
@@ -12,6 +12,11 @@ export const useHooks = () => {
     );
   }, []);
 
+  // 初回用
+  useEffect(() => {
+    handleScroll();
+  }, [handleScroll]);
+
   useEffect(() => {
     if (typeof window === undefined) return;
     window.addEventListener("scroll", () => {

--- a/src/templates/SiteFloatingNavigation/index.tsx
+++ b/src/templates/SiteFloatingNavigation/index.tsx
@@ -4,11 +4,13 @@ import styles from "./style.module.scss";
 
 export const SiteFloatingNavigation: React.FC = () => {
   const hooks = useHooks();
+  console.log("isScrollTop", hooks.isScrollStarted);
+  console.log("isWindowTop", hooks.isScrolled1vh);
   return (
     <nav
       className={`${styles["site-floating-nav"]} 
-      ${hooks.isScrollStart ? styles["is-scroll-start"] : ""} ${
-        hooks.isWindowTop ? styles["is-window-top"] : ""
+      ${hooks.isScrollStarted ? styles["is-scroll-start"] : ""} ${
+        hooks.isScrolled1vh ? styles["is-window-top"] : ""
       }
       `}
       ref={hooks.ref}


### PR DESCRIPTION
これにより、ページの中ほどまでスクロールしている状態でリロードするとナビゲーションバーが消える事象が直る