### PR TITLE
Netlify Form 用の記述を削除する

### DIFF
--- a/src/repositories/innerApp/index.ts
+++ b/src/repositories/innerApp/index.ts
@@ -1,4 +1,4 @@
-import { ContactFormItem, SubmitItem } from "@/types/ContactForm";
+import { ContactFormItem } from "@/types/ContactForm";
 
 const URL = "/api/receiveContactForm"; // Next.js api
 
@@ -17,11 +17,10 @@ export const postContactForm = (
 
 const encode = (contactFormItem: Partial<ContactFormItem>) => {
   const data = {
-    "form-name": "iyu-form", // todo: form 要素から取得できるか確認する。そのほうが堅牢
     ...contactFormItem,
   };
 
-  return (Object.keys(data) as (keyof SubmitItem)[])
+  return (Object.keys(data) as (keyof ContactFormItem)[])
     .map(
       (key) =>
         `${encodeURIComponent(key)}=${encodeURIComponent(data[key] || "")}`

--- a/src/templates/Contact/Form/index.tsx
+++ b/src/templates/Contact/Form/index.tsx
@@ -17,10 +17,7 @@ const FormParts: React.FC = () => {
   return (
     <form
       className={styles["contact-form"]}
-      data-netlify="true"
       method="POST"
-      name="iyu-form"
-      netlify-honeypot="bot-field" // todo: netlify の form に認識されるか確認し、要不要を決める。preventDefault 書いてるからたぶんだめ？
       onSubmit={hooks.onSubmit}
     >
       <Input

--- a/src/types/ContactForm.ts
+++ b/src/types/ContactForm.ts
@@ -25,5 +25,3 @@ interface UnSelectedLive extends Basic {
 }
 
 export type ContactFormItem = SelectedLive | UnSelectedLive;
-
-export type SubmitItem = ContactFormItem & { "form-name": string };


### PR DESCRIPTION
- Netlify Form は使わないことにし、fetch でAPIコールすることで送信することにしたため不要。
  - Netlify Form 側に認識されれば管理画面上でユーザーの送信をモニターできるためよさそうだが、（preventDefault しており、HTML Form の送信と fetch での送信を両立させるのが面倒な割にメリットも大きくないと思ったので）検証をしていない。