### PR TITLE
fix: selectボックスの値が初期値に戻った場合に見た目が未選択状態に戻らないのを修正する

### DIFF
--- a/src/templates/Contact/Form/hooks.ts
+++ b/src/templates/Contact/Form/hooks.ts
@@ -20,7 +20,7 @@ export const useHooks = () => {
       setUserInput((prev) => {
         return {
           ...prev,
-          [e.target.name]: e.target.value,
+          [e.target.name]: e.target.value || undefined,
         };
       });
     },


### PR DESCRIPTION
- セレクトボックスで何かを選択する→最初の選択肢に戻す の順で操作すると、プレースホルダーの色がグレーに戻らない事象を解決する
- これにより Context に保持している UserInput も undefined になるため、値が入っていないことがより明示的になるので、そういう意味でもこちらのほうがよさそう