### PR TITLE
Liveの日付の取得と表示を正しいものに改善する

### DIFF
--- a/src/providers/LiveInformationProvider/index.tsx
+++ b/src/providers/LiveInformationProvider/index.tsx
@@ -1,10 +1,35 @@
 import { Live } from "@/types";
-import { createContext, ReactNode } from "react";
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+import { createContext, ReactNode, useMemo } from "react";
+
+/**
+ * note: ライブ情報は一度しか取得しない、かつUI側から更新しないこと、扱う値が少なくて単純なことから、
+ * スケールしない作りになっている。
+ * useSelector 的な抽出をできるようにすれば一番良い。
+ */
+
+dayjs.locale("ja");
 
 type Lives = Live[];
+interface LabeledLive extends Omit<Live, "date"> {
+  date: string;
+}
+type LabeledLives = LabeledLive[];
 
 type State = {
-  lives: Lives;
+  lives: LabeledLives;
+};
+
+const generateLabeledLives = (state: Lives) => {
+  const _state = state.map((element) => {
+    const _element = {
+      ...element,
+      date: dayjs(element.date).format("YYYY/M/D (ddd)"),
+    };
+    return _element;
+  });
+  return _state;
 };
 
 export const LiveInformationContext = createContext<State>({
@@ -16,8 +41,18 @@ interface Props {
   lives: Lives;
 }
 
-export const LiveInformationProvider: React.FC<Props> = (props) => (
-  <LiveInformationContext.Provider value={{ lives: props.lives }}>
-    {props.children}
-  </LiveInformationContext.Provider>
-);
+export const LiveInformationProvider: React.FC<Props> = (props) => {
+  const labeledLives = useMemo(() => {
+    return generateLabeledLives(props.lives);
+  }, [props.lives]);
+
+  return (
+    <LiveInformationContext.Provider
+      value={{
+        lives: labeledLives,
+      }}
+    >
+      {props.children}
+    </LiveInformationContext.Provider>
+  );
+};

--- a/src/repositories/contentful/liveInfo/mockData.ts
+++ b/src/repositories/contentful/liveInfo/mockData.ts
@@ -2,7 +2,7 @@ import { Live } from "@/types";
 
 export const dummyLives: Live[] = [
   {
-    date: "2022/12/31 (Sat)",
+    date: "2022-12-31",
     title: "イベントaaa",
     place: "とあるライブハウス1",
     timeOpen: "17:00",
@@ -17,7 +17,7 @@ export const dummyLives: Live[] = [
     ],
   },
   {
-    date: "2023/1/31 (Sat)",
+    date: "2023-01-31",
     title: "イベントbbb とっても楽しくて名前がとてーもながいイベント",
     place: "とあるライブハウス2",
     timeOpen: "20:00",
@@ -26,7 +26,7 @@ export const dummyLives: Live[] = [
     with: ["ダミーシンガー", "ダミーソロアーティスト"],
   },
   {
-    date: "2024/1/24 (Mon)",
+    date: "2024-01-24",
     title: "イベントccc ご飯がおいしいイベント",
     place: "とあるライブハウス3",
     timeOpen: "11:30",

--- a/src/repositories/contentful/liveInfo/mockData.ts
+++ b/src/repositories/contentful/liveInfo/mockData.ts
@@ -17,7 +17,7 @@ export const dummyLives: Live[] = [
     ],
   },
   {
-    date: "2023-01-31",
+    date: "2023-01-01",
     title: "イベントbbb とっても楽しくて名前がとてーもながいイベント",
     place: "とあるライブハウス2",
     timeOpen: "20:00",

--- a/src/types/Live.ts
+++ b/src/types/Live.ts
@@ -1,5 +1,5 @@
 export type Live = {
-  date: string;
+  date: `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
   title: string;
   place: string;
   timeOpen: string;


### PR DESCRIPTION
- contentful から取得される生データの形式を型に反映させる
- useContext で保持しているデータを表示する形式に変えてしまう
- 残タスク: 正しく日付順になっていないので改善する