### PR TITLE
refactor: テキストリンクコンポーネントを共通化する

### DIFF
--- a/src/components/TextLink/index.tsx
+++ b/src/components/TextLink/index.tsx
@@ -1,0 +1,26 @@
+import { ComponentPropsWithoutRef, ReactNode } from "react";
+import AnchorLink from "react-anchor-link-smooth-scroll";
+import styles from "./style.module.scss";
+
+// 通常のaタグ
+interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  children: ReactNode;
+}
+
+export const TextLink: React.FC<Props> = (props) => (
+  <a {...props} className={`${styles["root"]} ${props.className}`}>
+    {props.children}
+  </a>
+);
+
+// アンカージャンプする場合
+export const TextAnchorLink: React.FC<
+  ComponentPropsWithoutRef<typeof AnchorLink>
+> = (props) => {
+  const { children, className, ...rest } = props;
+  return (
+    <AnchorLink {...rest} className={`${styles["root"]} ${className}`}>
+      {children}
+    </AnchorLink>
+  );
+};

--- a/src/components/TextLink/style.module.scss
+++ b/src/components/TextLink/style.module.scss
@@ -1,20 +1,18 @@
 @import "variables";
 @import "functions";
 
-// todo: 共通化する
 @mixin selection-color() {
   &::selection {
     background: $yellow-rgba;
-    color: $main-blue;
   }
 }
 
-.lead {
+.root {
   color: $white;
-  text-align: center;
-  line-height: 2;
+  text-decoration: underline;
+  margin: 0 0.1em;
   @include selection-color();
-  @include mq() {
-    line-height: 1.5;
+  &:hover {
+    text-decoration: none;
   }
 }

--- a/src/templates/Live/InformationText/index.tsx
+++ b/src/templates/Live/InformationText/index.tsx
@@ -1,4 +1,4 @@
-import AnchorLink from "react-anchor-link-smooth-scroll";
+import { TextAnchorLink, TextLink } from "@/components/TextLink";
 import { useHooks } from "./hooks";
 import styles from "./style.module.scss";
 
@@ -9,23 +9,21 @@ export const InformationText: React.FC = () => {
       {hooks.lives.length > 0 ? (
         <p className={styles["lead"]}>
           <span>チケットのお取置きは</span>
-          <AnchorLink
-            className={styles["text-link"]}
+          <TextAnchorLink
             href={`#${hooks.anchorList.contact.id}`}
             offset={hooks.anchorList.contact.offset}
           >
             こちらのフォーム
-          </AnchorLink>
+          </TextAnchorLink>
           から。
           <br />
-          <a
-            className={styles["text-link"]}
+          <TextLink
             href="https://twitter.com/iyu_band"
             rel="noreferrer"
             target="_blank"
           >
             Twitter
-          </a>
+          </TextLink>
           でも承っております。
         </p>
       ) : (
@@ -34,14 +32,13 @@ export const InformationText: React.FC = () => {
           <br />
           発表をお待ち下さい！
           <br />
-          <a
-            className={styles["text-link"]}
+          <TextLink
             href="https://twitter.com/iyu_band"
             rel="noreferrer"
             target="_blank"
           >
             Twitter
-          </a>
+          </TextLink>
           もぜひチェックしてくださいね。
         </p>
       )}

--- a/src/templates/MainVisual/InformationSummary/style.module.scss
+++ b/src/templates/MainVisual/InformationSummary/style.module.scss
@@ -60,14 +60,3 @@
     margin-top: 5px;
   }
 }
-
-// todo: コンポーネントに切り出し
-.text-link {
-  color: $white;
-  text-decoration: underline;
-  margin: 0 0.2em;
-  @include selection-color();
-  &:hover {
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
- `AnchorLink` とスタイルを共通化するため同じファイルに移動