### PR TITLE
GTM & GA4 を有効化する

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,3 +5,4 @@ LINE_NOTIFY_TOKEN=xxxxxxxx # dev / prd の出し分けは Netlify の機能を�
 MAIL_USER=xxxxxxxx
 MAIL_PASS=xxxxxxxx
 MAIL_TO_IYU_MEMBER=xxxxxxxx
+GOOGLE_TAG_MANAGER_CONTAINER_ID=GTM-xxxxxxx

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,8 @@ const nextConfig = {
     APP_ENV: process.env.APP_ENV, // NODE_ENV には `local` が存在しないので作成した。
     CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID,
     CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN,
+    GOOGLE_TAG_MANAGER_CONTAINER_ID:
+      process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID,
   },
 };
 

--- a/src/components/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager.tsx
@@ -4,20 +4,18 @@ interface Props {
   containerId: string;
 }
 
-export const GoogleTagManager: React.FC<Props> = (props) => {
-  return (
-    <Script
-      id="gtm"
-      strategy="afterInteractive"
-      dangerouslySetInnerHTML={{
-        __html: `
+export const GoogleTagManager: React.FC<Props> = (props) => (
+  <Script
+    id="gtm"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','${props.containerId}');
       `,
-      }}
-    />
-  );
-};
+    }}
+  />
+);

--- a/src/components/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager.tsx
@@ -1,0 +1,23 @@
+import Script from "next/script";
+
+interface Props {
+  containerId: string;
+}
+
+export const GoogleTagManager: React.FC<Props> = (props) => {
+  return (
+    <Script
+      id="gtm"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${props.containerId}');
+      `,
+      }}
+    />
+  );
+};

--- a/src/components/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager.tsx
@@ -6,8 +6,6 @@ interface Props {
 
 export const GoogleTagManager: React.FC<Props> = (props) => (
   <Script
-    id="gtm"
-    strategy="afterInteractive"
     dangerouslySetInnerHTML={{
       __html: `
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -17,5 +15,7 @@ export const GoogleTagManager: React.FC<Props> = (props) => (
       })(window,document,'script','dataLayer','${props.containerId}');
       `,
     }}
+    id="gtm"
+    strategy="afterInteractive"
   />
 );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { AppHead } from "@/components/AppHead";
+import { GoogleTagManager } from "@/components/GoogleTagManager";
 import "@/styles/base.css";
 import type { AppProps } from "next/app";
 
@@ -6,6 +7,9 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <AppHead />
+      <GoogleTagManager
+        containerId={process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID}
+      />
       <Component {...pageProps} />
     </>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <AppHead />
+      {/* note: Next.js の使用で head 内に置けない */}
       <GoogleTagManager
         containerId={process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID}
       />

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -6,5 +6,6 @@ declare namespace NodeJS {
     readonly CONTENTFUL_SPACE_ID: string;
     readonly CONTENTFUL_ACCESS_TOKEN: string;
     readonly LINE_NOTIFY_TOKEN: string;
+    readonly GOOGLE_TAG_MANAGER_CONTAINER_ID: string;
   }
 }


### PR DESCRIPTION
- GA4をGTM経由で提供する。 [参考](https://dabohaze.site/ga4-google-tag-manager-env-dev/)
- 本番環境のみで計測を有効化するようにしている。[参考](https://dabohaze.site/ga4-google-tag-manager-env-dev/)
  - そのため Netlify GUI 上での環境変数は全環境に本番の値を入れている
    - よりよい方法があればその際に変更する