### PR TITLE
Contactフォームの本文に文字数制限を設ける

### DIFF
--- a/src/components/Textarea/style.module.scss
+++ b/src/components/Textarea/style.module.scss
@@ -12,6 +12,7 @@
   outline-color: $yellow-rgba;
   resize: vertical;
   height: 10em;
+  vertical-align: bottom;
   &::placeholder {
     color: $placeholder;
   }

--- a/src/templates/Contact/Form/hooks.ts
+++ b/src/templates/Contact/Form/hooks.ts
@@ -4,6 +4,7 @@ import {
   FormEvent,
   useCallback,
   useContext,
+  useMemo,
   useState,
 } from "react";
 import { UserInputContext } from "./UserInputProvider";
@@ -27,6 +28,12 @@ export const useHooks = () => {
     },
     [setUserInput]
   );
+
+  // todo: context 側に寄せる
+  const userMessageLength = useMemo(() => {
+    if (!userInput.message) return 0;
+    return userInput.message.length;
+  }, [userInput.message]);
 
   const onSubmit = useCallback(
     async (e: FormEvent) => {
@@ -52,5 +59,6 @@ export const useHooks = () => {
     onChange,
     onSubmit,
     isFormDisabled,
+    userMessageLength,
   };
 };

--- a/src/templates/Contact/Form/index.tsx
+++ b/src/templates/Contact/Form/index.tsx
@@ -12,6 +12,12 @@ export const Form: React.FC = () => (
   </UserInputProvider>
 );
 
+// note:
+// LINE notify の文字数制限が1000文字だが、長文を送信したい人も多そうなので多めの設定をしている。
+// 見切れたぶんはメールで見られるのでいったん今は許容する。
+// todo: サーバーサイドで分割送信をできるようにする。
+const MESSAGE_MAX_LENGTH = 1500;
+
 const FormParts: React.FC = () => {
   const hooks = useHooks();
   return (
@@ -36,11 +42,15 @@ const FormParts: React.FC = () => {
         type="email"
       />
       <Textarea
+        maxLength={MESSAGE_MAX_LENGTH}
         name="message"
         onChange={hooks.onChange}
         placeholder="内容"
         required
       />
+      <p className={styles["user-input-length"]}>
+        {hooks.userMessageLength} / {MESSAGE_MAX_LENGTH}
+      </p>
       <SubmitButton
         className={styles["send-button"]}
         disabled={hooks.isFormDisabled}

--- a/src/templates/Contact/Form/style.module.scss
+++ b/src/templates/Contact/Form/style.module.scss
@@ -8,3 +8,10 @@
 .send-button {
   margin-top: 10px;
 }
+
+.user-input-length {
+  color: $white;
+  text-align: right;
+  font-size: 14px;
+  margin-top: 2px;
+}


### PR DESCRIPTION
- 背景: LINE notify は1000文字制限であり、見切れることが多いので文字数制限を設けたい
- サーバーサイドでLINEに分割送信できるようにするのが恒久対応として良さそうだが、今回はフロントのみ＝このPullReqをマージしても見切れる問題は解決しない
- 件名やメールアドレスなどの文字数を差し引いての適切な文字数も追って考える