### PR TITLE
画像にローディングプレイスホルダーを与える

### DIFF
--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -1,0 +1,16 @@
+@import "variables";
+
+@mixin loading-placeholder() {
+  background: linear-gradient(to right, $light-gray, $gray, $light-gray);
+  background-size: 200% 200%;
+  animation: gradient 1s linear infinite;
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0;
+  }
+  100% {
+    background-position: top 0 left -200%;
+  }
+}

--- a/src/templates/Gallery/Carousel/style.module.scss
+++ b/src/templates/Gallery/Carousel/style.module.scss
@@ -1,22 +1,12 @@
 @import "variables";
 @import "functions";
+@import "utils";
 
 .image {
   display: block;
   width: 100%;
   height: auto;
-  background: linear-gradient(to right, $light-gray, $gray, $light-gray);
-  background-size: 200% 200%;
-  animation: gradient 1s linear infinite;
-}
-
-@keyframes gradient {
-  0% {
-    background-position: 0;
-  }
-  100% {
-    background-position: top 0 left -200%;
-  }
+  @include loading-placeholder();
 }
 
 // ____________ for splide ____________

--- a/src/templates/Gallery/Carousel/style.module.scss
+++ b/src/templates/Gallery/Carousel/style.module.scss
@@ -5,7 +5,18 @@
   display: block;
   width: 100%;
   height: auto;
-  background: $gray;
+  background: linear-gradient(to right, $light-gray, $gray, $light-gray);
+  background-size: 200% 200%;
+  animation: gradient 1s linear infinite;
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0;
+  }
+  100% {
+    background-position: top 0 left -200%;
+  }
 }
 
 // ____________ for splide ____________

--- a/src/templates/Goods/GoodsCard/style.module.scss
+++ b/src/templates/Goods/GoodsCard/style.module.scss
@@ -1,5 +1,6 @@
 @import "variables";
 @import "functions";
+@import "utils";
 
 .anchor {
   position: relative;
@@ -25,6 +26,7 @@
     position: static;
     transform: none;
   }
+  @include loading-placeholder();
 }
 
 .overlay {


### PR DESCRIPTION
- Netlify の画像ロードが遅いため
- UIそのもののplaceholderは現状不要のためCSSで作成
  - 何かを非同期で待ってから表示するUIがない