### PR TITLE
[skip netlify] .env.localに注意喚起コメントを追加する

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,8 +1,10 @@
+# caution:
+# 行の後ろにコメントを書けず、値の一部として認識されてしまうため、 .env.local にコピーしたら削除すること。
 APP_ENV=local
 CONTENTFUL_SPACE_ID=xxxxxxxx
 CONTENTFUL_ACCESS_TOKEN=xxxxxxxx
 LINE_NOTIFY_TOKEN=xxxxxxxx # dev / prd の出し分けは Netlify の機能を使っている
 MAIL_USER=xxxxxxxx
-MAIL_PASS=xxxxxxxx
+MAIL_PASS=xxxxxxxx # ログインパスワードではなくアプリパスワード
 MAIL_TO_IYU_MEMBER=xxxxxxxx
 GOOGLE_TAG_MANAGER_CONTAINER_ID=GTM-xxxxxxx


### PR DESCRIPTION
行の末尾にコメントが付けられない様子。

```
TEST=xxx # comment
```

を書くと、

```
console.log(process.env.TEST); // output: xxx # comment 
```