### PR TITLE
Fix SCSS deprecation warnings

### DIFF
--- a/src/components/SiteFooter/style.module.scss
+++ b/src/components/SiteFooter/style.module.scss
@@ -5,11 +5,12 @@
   color: $white;
   width: 100%;
   padding: 40px $side-padding-pc;
+  background-color: $main-blue;
+  border-top: 1px solid $white;
+  
   @include mq() {
     padding: 30px $side-padding-sp;
   }
-  background-color: $main-blue;
-  border-top: 1px solid $white;
 }
 .contact-list {
   color: $white;

--- a/src/styles/functions.scss
+++ b/src/styles/functions.scss
@@ -1,6 +1,8 @@
 // for media query
+@use "sass:map";
+
 @mixin mq($breakpoint: sm) {
-  @media (#{map-get($breakpoints, $breakpoint)}) {
+  @media (#{map.get($breakpoints, $breakpoint)}) {
     @content;
   }
 }

--- a/src/templates/Goods/GoodsCard/style.module.scss
+++ b/src/templates/Goods/GoodsCard/style.module.scss
@@ -22,11 +22,12 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  @include loading-placeholder();
+  
   @include mq() {
     position: static;
     transform: none;
   }
-  @include loading-placeholder();
 }
 
 .overlay {


### PR DESCRIPTION
## Summary
- Replace deprecated `map-get()` with `map.get()` using modern `@use "sass:map"` syntax  
- Fix mixed declarations by moving CSS properties before nested rules in SiteFooter
- Reorder `@include loading-placeholder()` before `@include mq()` in GoodsCard

## Test plan
- [x] Run `npm ci` to verify warnings are resolved
- [x] Confirm build completes successfully 
- [x] Check that functionality remains unchanged

This resolves the following SCSS deprecation warnings that appear during `npm ci`:
- `DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated`
- `DEPRECATION WARNING [mixed-decls]: CSS properties appearing after nested rules`

🤖 Generated with [Claude Code](https://claude.ai/code)